### PR TITLE
Gcore Rest Api/ sHINER Tab

### DIFF
--- a/config/gcore.env.example
+++ b/config/gcore.env.example
@@ -1,0 +1,1 @@
+GCORE_ENDPOINT=http://diascld32.iccluster.epfl.ch:6080/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - ./config/postgres.env
       - ./config/proteus.env
       - ./config/qal.env
+      - ./config/gcore.env
     working_dir: /usr/src/app
     command: ["python", "app.py", "--port", "8080", "--dev"]
     depends_on:
@@ -96,7 +97,7 @@ services:
     command: ["sh", "-c", "npm install && npx bower --allow-root install && npx grunt serve"]
     networks:
       - sdl_net
-  
+
   ####################
   # Postgres Test DB #
   ####################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.7'
 networks:
   sdl_net:
    name: sdl_net
+   external: true
 
 services:
   #######################
@@ -20,8 +21,9 @@ services:
     command: ["sh", "-c", "npm install && npm rebuild node-sass && npm run-script start"]
     depends_on:
       - visual-analytics-engine
-    networks:
-      - sdl_net
+    network_mode: host
+    #networks:
+    #  - sdl_net
 
   ###############################
   # SDL Visual Analytics Engine #
@@ -33,7 +35,8 @@ services:
       context: ./visual-analytics-engine/
       dockerfile: ./Dockerfile
     ports:
-      - "3001:8080"
+    - "3001:8080"
+    # - "3001:3001"
     volumes:
       - ./visual-analytics-engine/app:/usr/src/app
       - ./visual-analytics-engine/data/input:/data/input
@@ -44,11 +47,13 @@ services:
       - ./config/qal.env
       - ./config/gcore.env
     working_dir: /usr/src/app
+    #command: ["python", "app.py", "--port", "3001", "--dev"]
     command: ["python", "app.py", "--port", "8080", "--dev"]
     depends_on:
       - redis
-    networks:
-      - sdl_net
+    network_mode: host
+    #networks:
+    #  - sdl_net
 
   #########
   # Redis #
@@ -60,8 +65,9 @@ services:
     hostname: redis
     volumes:
       - redis-data:/data
-    networks:
-      - sdl_net
+    network_mode: host
+    #networks:
+    #  - sdl_net
 
   ###############
   # JUPYTER LAB #
@@ -80,8 +86,9 @@ services:
       - ./config/proteus.env
     working_dir: /home/jovyan
     command: ["sh", "-c", "cd /home/jovyan/notebooks && jupyter-lab --port=3002"]
-    networks:
-      - sdl_net
+    network_mode: host
+    #networks:
+    #  - sdl_net
 
   ###########
   # V-Plots #
@@ -95,8 +102,9 @@ services:
       - ./v-plots/app:/usr/src/app
     working_dir: /usr/src/app
     command: ["sh", "-c", "npm install && npx bower --allow-root install && npx grunt serve"]
-    networks:
-      - sdl_net
+    network_mode: host
+    #networks:
+    # - sdl_net
 
   ####################
   # Postgres Test DB #
@@ -111,8 +119,9 @@ services:
       - ./config/postgres.env
     ports:
       - "3004:5432"
-    networks:
-      - sdl_net
+    network_mode: host
+    #networks:
+    #  - sdl_net
 
 
 volumes:

--- a/visual-analytics-engine/app/app.py
+++ b/visual-analytics-engine/app/app.py
@@ -150,6 +150,18 @@ def make_flask_app() -> Flask:
         args = request.json
         return gcore_manager.getNeighborsGraph(args)
 
+    ###############graph visualization#############
+
+    @app.route("/graphvis/initialvis", methods=['POST'])
+    def graph_initialvis():
+        args = request.json
+        return gcore_manager.startVisualization(args)
+
+    @app.route("/graphvis/nextlevel", methods=['POST'])
+    def graph_nextlevel():
+        args = request.json
+        return gcore_manager.nextLevelGraph(args)
+
     ##############################
 
     # Renamed from /tables to /schema to avoid confusion

--- a/visual-analytics-engine/app/tools/gcore_manager.py
+++ b/visual-analytics-engine/app/tools/gcore_manager.py
@@ -1,0 +1,97 @@
+import requests
+import json
+import pandas as pd
+import networkx as nx
+
+
+class GCoreManager:
+    _service_url = None
+
+    def __init__(self, gcore_endpoint):
+        self._service_url = gcore_endpoint
+        r = requests.get(self._service_url + 'graphDB')
+        print(r.content)
+
+    def get_graphs(self):
+        print("GCore service url::" + self._service_url)
+        r = requests.get(self._service_url + 'graphDB')
+        print(r.content)
+        return r.content
+
+    def graph_schema(self, name=None):
+        urlGCore = self._service_url + 'graphDB/' + name
+        r = requests.get(url=urlGCore)
+        return r.content
+
+    def set_ggds(self, ggds):
+        r = requests.post(url=self._service_url + 'ggds/setGGDs', json=ggds)
+        print("Here answer to content:" + r.content)
+        return r.content
+
+    def get_ggds(self):
+        r = requests.get(url=self._service_url+'ggds/getGGDs')
+        return r.content
+
+    def run_ER(self):
+        r = requests.get(url=self._service_url+'ggds/runER')
+        print(r.content)
+        return r.content
+
+    def selectQuery(self, query, limit):
+        #json = {"key": "value"}
+        r = requests.post(url=self._service_url + 'gcore/select', json={"query": query, "limit": limit})
+        #r = requests.post(url=service_url + 'gcore/select', data=query)
+        #tableData = pd.DataFrame.from_dict(json.loads(r['content']))
+        tableData = r.content
+        return tableData
+
+    def constructQuery(self, query, limit):
+        print(query)
+        r = requests.post(url=self._service_url + 'gcore/construct', json={"query": query, "limit": limit})
+        #r = requests.post(url=service_url + "gcore/construct", data=query)
+        jsonobj = json.loads(r.content)
+        print(r.content)
+        graph = r.content#nx.readwrite.json_graph.node_link_graph(r.content)
+        return graph
+
+    def selectQuery_table(self, tableName, graphName=None):
+        if graphName is None:
+            query = "SELECT * MATCH (a:" + tableName + ")"
+        else:
+            query = "SELECT * MATCH (a:" + tableName + ") ON " + graphName
+        r = requests.post(url=self._service_url+'gcore/select', data=query)
+        tableData = pd.DataFrame.from_dict(json.loads(r['content']))
+        return tableData
+
+    def constructQuery_graph(self, resPattern, matchPattern, graphName=None):
+        if graphName is None:
+            query = "CONSTRUCT " + resPattern + " MATCH " + matchPattern
+        else:
+            query = "CONSTRUCT " + resPattern + " MATCH " + matchPattern + " ON " + graphName
+        r = requests.post(url=self._service_url+"gcore/construct", data=query)
+        graph = nx.readwrite.json_graph.node_link_graph(r.content)
+        return graph
+
+#example json file
+#    with open("data/graph.txt") as json_file:
+#        jsonParam = json.load(json_file)
+#    print(jsonParam)
+#    r = requests.post(url='http://localhost:8080/gcore/construct-neighbor', json=jsonParam)
+
+#json format for "passing node information"
+#{
+#        "nodeLabel": "ProductAmazon",
+#        "id": "1",
+#        "edgeLabel": "",
+#        "graphName": "Amazon",
+#        "limit": -1
+#    }
+    def getNeighbors(self, nodeParam):
+        r = requests.post(url=self._service_url+"gcore/select-neighbor",json=nodeParam)
+        neighborData = pd.DataFrame.from_dict(json.loads(r['content']))
+        return neighborData
+
+    def getNeighborsGraph(self, nodeParam):
+        r = requests.post(url=self._service_url+"gcore/construct-neighbor",json=nodeParam)
+        graphNeighbor = nx.readwrite.json_graph.node_link_graph(r.content)
+        return graphNeighbor

--- a/visual-analytics-engine/app/tools/gcore_manager.py
+++ b/visual-analytics-engine/app/tools/gcore_manager.py
@@ -95,3 +95,17 @@ class GCoreManager:
         r = requests.post(url=self._service_url+"gcore/construct-neighbor",json=nodeParam)
         graphNeighbor = nx.readwrite.json_graph.node_link_graph(r.content)
         return graphNeighbor
+
+    def startVisualization(self, param):
+        print(param)
+        r = requests.post(url=self._service_url+"graphvis/initialvis", json=param)
+        print(r.content)
+        return r.content#jsonify(data=r.content)
+        #initialGraph = nx.readwrite.json_graph.node_link_graph(r.content)
+        #return initialGraph
+
+    def nextLevelGraph(self, param):
+        print(param)
+        r = requests.post(url=self._service_url+"graphvis/nextlevel", json=param)
+        print(r.content)
+        return r.content#jsonify(data=r.content)

--- a/visual-analytics-engine/data/input/gcore/ggd1Amazon.json
+++ b/visual-analytics-engine/data/input/gcore/ggd1Amazon.json
@@ -1,0 +1,184 @@
+[
+  {
+    "sourceGP": [
+      {
+        "name": "Amazon",
+        "vertices": [
+          {
+            "label": "ProductAmazon",
+            "variable": "VS"
+          },
+          {
+            "label": "ManufacturerAmazon",
+            "variable": "lV"
+          }
+        ],
+        "edges": [
+          {
+            "label": "producedbyAmazon",
+            "variable": "WaO",
+            "fromVariable": "VS",
+            "toVariable": "lV"
+          }
+        ]
+      },
+      {
+        "name": "Google",
+        "vertices": [
+          {
+            "label": "ProductGoogle",
+            "variable": "zc"
+          },
+          {
+            "label": "ManufacturerGoogle",
+            "variable": "DX"
+          }
+        ],
+        "edges": [
+          {
+            "label": "producedbyGoogle",
+            "variable": "Ymc",
+            "fromVariable": "zc",
+            "toVariable": "DX"
+          }
+        ]
+      }
+    ],
+    "sourceCons": [],
+    "targetGP": [
+      {
+        "name": "AmazonGoogle",
+        "vertices": [
+          {
+            "label": "ProductAmazon",
+            "variable": "VS"
+          },
+          {
+            "label": "ManufacturerAmazon",
+            "variable": "lV"
+          },
+          {
+            "label": "ProductGoogle",
+            "variable": "zc"
+          },
+          {
+            "label": "ManufacturerGoogle",
+            "variable": "DX"
+          }
+        ],
+        "edges": [
+          {
+            "label": "producedbyAmazon",
+            "variable": "WaO",
+            "fromVariable": "VS",
+            "toVariable": "lV"
+          },
+          {
+            "label": "producedbyGoogle",
+            "variable": "Ymc",
+            "fromVariable": "zc",
+            "toVariable": "DX"
+          },
+          {
+            "label": "sameAs_ggd1",
+            "variable": "AxAh",
+            "fromVariable": "VS",
+            "toVariable": "zc"
+          }
+        ]
+      }
+    ],
+    "targetCons": []
+  },
+  {
+    "sourceGP": [
+      {
+        "name": "Amazon",
+        "vertices": [
+          {
+            "label": "ProductAmazon",
+            "variable": "VS"
+          },
+          {
+            "label": "ManufacturerAmazon",
+            "variable": "lV"
+          }
+        ],
+        "edges": [
+          {
+            "label": "producedbyAmazon",
+            "variable": "WaO",
+            "fromVariable": "VS",
+            "toVariable": "lV"
+          }
+        ]
+      },
+      {
+        "name": "Google",
+        "vertices": [
+          {
+            "label": "ProductGoogle",
+            "variable": "zc"
+          },
+          {
+            "label": "ManufacturerGoogle",
+            "variable": "DX"
+          }
+        ],
+        "edges": [
+          {
+            "label": "producedbyGoogle",
+            "variable": "Ymc",
+            "fromVariable": "zc",
+            "toVariable": "DX"
+          }
+        ]
+      }
+    ],
+    "sourceCons": [],
+    "targetGP": [
+      {
+        "name": "AmazonGoogle",
+        "vertices": [
+          {
+            "label": "ProductAmazon",
+            "variable": "VS"
+          },
+          {
+            "label": "ManufacturerAmazon",
+            "variable": "lV"
+          },
+          {
+            "label": "ProductGoogle",
+            "variable": "zc"
+          },
+          {
+            "label": "ManufacturerGoogle",
+            "variable": "DX"
+          }
+        ],
+        "edges": [
+          {
+            "label": "producedbyAmazon",
+            "variable": "WaO",
+            "fromVariable": "VS",
+            "toVariable": "lV"
+          },
+          {
+            "label": "producedbyGoogle",
+            "variable": "Ymc",
+            "fromVariable": "zc",
+            "toVariable": "DX"
+          },
+          {
+            "label": "sameAs_ggd1",
+            "variable": "AxAh",
+            "fromVariable": "VS",
+            "toVariable": "zc"
+          }
+        ]
+      }
+    ],
+    "targetCons": []
+  }
+]

--- a/visual-analytics-engine/data/input/gcore/graph.txt
+++ b/visual-analytics-engine/data/input/gcore/graph.txt
@@ -1,0 +1,7 @@
+{
+        "nodeLabel": "ProductAmazon",
+        "id": "1",
+        "edgeLabel": "",
+        "graphName": "Amazon",
+        "limit": -1
+    }

--- a/visual-explorer/app/package-lock.json
+++ b/visual-explorer/app/package-lock.json
@@ -1038,7 +1038,7 @@
     "@emotion/is-prop-valid": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "integrity": "sha1-2yixxDaKJZtgqXMR1qlS1P0BrBo=",
       "requires": {
         "@emotion/memoize": "0.7.4"
       }
@@ -1046,17 +1046,17 @@
     "@emotion/memoize": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+      "integrity": "sha1-Gb8PWvGRSREcQNmLsM+CEZ9dnus="
     },
     "@emotion/stylis": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+      "integrity": "sha1-3qyzib1u530ef8rMzp4WxcfnjgQ="
     },
     "@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+      "integrity": "sha1-dyESkcGQCnALinjPr9oxYNdpSe0="
     },
     "@hapi/address": {
       "version": "2.0.0",
@@ -1481,17 +1481,17 @@
     "@popperjs/core": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.4.tgz",
-      "integrity": "sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg=="
+      "integrity": "sha1-EdXbGb0XiTbsic2EUZxN5DlXQ5g="
     },
     "@restart/context": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
-      "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q=="
+      "integrity": "sha1-qZ2HwpmjTCi9hbtInLB7/SMUnAI="
     },
     "@restart/hooks": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.25.tgz",
-      "integrity": "sha512-m2v3N5pxTsIiSH74/sb1yW8D9RxkJidGW+5Mfwn/lHb2QzhZNlaU1su7abSyT9EGf0xS/0waLjrf7/XxQHUk7w==",
+      "integrity": "sha1-EQBBOa0ccNL1llqJOdy1rrlqplI=",
       "requires": {
         "lodash": "^4.17.15",
         "lodash-es": "^4.17.15"
@@ -2012,7 +2012,7 @@
     "@types/lodash": {
       "version": "4.14.161",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
-      "integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==",
+      "integrity": "sha1-ohygd32rxuT0Tz0H83t2X1QYixg=",
       "dev": true
     },
     "@types/matter-js": {
@@ -2112,7 +2112,7 @@
     "@types/react-transition-group": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
-      "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
+      "integrity": "sha1-iCg520Zd8TIOR1Pm6fcMp+m01G0=",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -3059,7 +3059,7 @@
     "babel-plugin-styled-components": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.11.1.tgz",
-      "integrity": "sha512-YwrInHyKUk1PU3avIRdiLyCpM++18Rs1NgyMXEAQC33rIXs/vro0A+stf4sT0Gf22Got+xRWB8Cm0tw+qkRzBA==",
+      "integrity": "sha1-Upap5VfXNsMYa+B5//J8ZmXWPXY=",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
@@ -5037,7 +5037,7 @@
     "css-to-react-native": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
-      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "integrity": "sha1-YtvmeAcqgkpom8/uAR/JbgKn11Y=",
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -5047,7 +5047,7 @@
         "postcss-value-parser": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-          "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
+          "integrity": "sha1-RD9qIM7WSBor2k+oUypuVdeJoss="
         }
       }
     },
@@ -5873,7 +5873,7 @@
     "dom-helpers": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
-      "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+      "integrity": "sha1-V/0FTF+PNMUqPu/9t+fpPNNX2Vs=",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -5882,7 +5882,7 @@
         "@babel/runtime": {
           "version": "7.11.2",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "integrity": "sha1-9UnBPHVMxAuHZEufqfCaapX+BzY=",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -5895,7 +5895,7 @@
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+          "integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U="
         }
       }
     },
@@ -11163,12 +11163,12 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI="
     },
     "lodash-es": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
+      "integrity": "sha1-Ib2Wg5NUQS8j16EDQOXqxu5FXXg="
     },
     "lodash._getnative": {
       "version": "3.9.1",
@@ -13836,7 +13836,7 @@
     "prop-types-extra": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
-      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
+      "integrity": "sha1-WMO3TL+7ldMEYll1qi8ISDKaAQs=",
       "requires": {
         "react-is": "^16.3.2",
         "warning": "^4.0.0"
@@ -14413,7 +14413,7 @@
     "react-icons": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-3.11.0.tgz",
-      "integrity": "sha512-JRgiI/vdF6uyBgyZhVyYJUZAop95Sy4XDe/jmT3R/bKliFWpO/uZBwvSjWEdxwzec7SYbEPNPck0Kff2tUGM2Q==",
+      "integrity": "sha1-LKKQPfq4Joyhjr2Mwuh5kh7DslQ=",
       "requires": {
         "camelcase": "^5.0.0"
       },
@@ -14421,7 +14421,7 @@
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
         }
       }
     },
@@ -14578,7 +14578,7 @@
     "react-transition-group": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
-      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+      "integrity": "sha1-Y4aPkyWjjqXulTXYKDJ/hXczRck=",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -14898,6 +14898,14 @@
         "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+          "dev": true
+        }
       }
     },
     "request-promise-core": {
@@ -15782,6 +15790,12 @@
           "requires": {
             "websocket-driver": ">=0.5.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+          "dev": true
         }
       }
     },
@@ -16841,7 +16855,7 @@
     "tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+      "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -16892,7 +16906,7 @@
     "typed-rest-client": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.7.3.tgz",
-      "integrity": "sha512-CwTpx/TkRHGZoHkJhBcp4X8K3/WtlzSHVQR0OIFnt10j4tgy4ypgq/SrrgVpA1s6tAL49Q6J3R5C0Cgfh2ddqA==",
+      "integrity": "sha1-G+smO4axTTRZb2Enxhct1f1lLns=",
       "requires": {
         "qs": "^6.9.1",
         "tunnel": "0.0.6",
@@ -16902,7 +16916,7 @@
         "qs": {
           "version": "6.9.4",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-          "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+          "integrity": "sha1-kJCykNH5FyjTwi5UhDykSupatoc="
         }
       }
     },
@@ -16950,7 +16964,7 @@
     "uncontrollable": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.1.1.tgz",
-      "integrity": "sha512-EcPYhot3uWTS3w00R32R2+vS8Vr53tttrvMj/yA1uYRhf8hbTG2GyugGqWDY0qIskxn0uTTojVd6wPYW9ZEf8Q==",
+      "integrity": "sha1-9n/tPvk2NxJlcYCXRjI6nbgV1VY=",
       "requires": {
         "@babel/runtime": "^7.6.3",
         "@types/react": "^16.9.11",
@@ -17250,9 +17264,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha1-xcnyyM8l3Ao3LE3xRBxB9b0MaAs=",
       "dev": true
     },
     "v8-compile-cache": {
@@ -17293,6 +17307,24 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "vis-data": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-7.0.0.tgz",
+      "integrity": "sha1-cf+OwG5NC5nxyM3s/flzCetFYs8=",
+      "dev": true
+    },
+    "vis-network": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-8.3.2.tgz",
+      "integrity": "sha1-Ip4laekfDp85H4wyypNeMgqE04g=",
+      "dev": true
+    },
+    "vis-util": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-4.3.4.tgz",
+      "integrity": "sha1-AjGfvZCfgngrlqNtEiTxvupn+LI=",
+      "dev": true
     },
     "vm-browserify": {
       "version": "1.1.0",
@@ -17611,6 +17643,14 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+          "dev": true
+        }
       }
     },
     "webpack-manifest-plugin": {

--- a/visual-explorer/app/package-lock.json
+++ b/visual-explorer/app/package-lock.json
@@ -14162,7 +14162,7 @@
         "@types/react": {
           "version": "16.9.49",
           "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
-          "integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+          "integrity": "sha1-CdsCHPgImroM2xKkn4AhppzOSHI=",
           "requires": {
             "@types/prop-types": "*",
             "csstype": "^3.0.2"
@@ -14171,7 +14171,7 @@
         "csstype": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+          "integrity": "sha1-K0ELvro4upYzNTr/NLBdl1XQZfg="
         }
       }
     },
@@ -16231,7 +16231,7 @@
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "requires": {
             "has-flag": "^3.0.0"
           }

--- a/visual-explorer/app/package.json
+++ b/visual-explorer/app/package.json
@@ -27,7 +27,11 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-eslint-rules": "^5.4.0",
     "tslint-react": "^4.2.0",
-    "typescript": "3.5.3"
+    "typescript": "3.5.3",
+    "uuid": "^7.0.3",
+    "vis-data": "^7.0.0",
+    "vis-network": "^8.2.0",
+    "vis-util": "^4.3.4"
   },
   "dependencies": {
     "bootstrap": "^4.3.1",

--- a/visual-explorer/app/src/components/Dashboard/Dashboard.tsx
+++ b/visual-explorer/app/src/components/Dashboard/Dashboard.tsx
@@ -8,6 +8,7 @@ import SimSearchProjectionTab from 'components/Dashboard/SimSearchProjectionTab/
 import ProfilingTab from 'components/Dashboard/ProfilingTab';
 import VPlotsTab from 'components/Dashboard/vPlotsTab';
 import TimeSeriesTab from 'components/Dashboard/TimeSeriesTab';
+import ShinerTab from "components/Dashboard/ShinerTab";
 import 'bootstrap/dist/css/bootstrap.min.css';
 
 interface IDashboardProps {
@@ -15,34 +16,35 @@ interface IDashboardProps {
 }
 
 const Dashboard = (props: IDashboardProps) => {
-    return (
-        <div className={'dashboard'}>
-            <Tabs
-                defaultActiveKey="simsearch-projection"
-                id="uncontrolled-tab-example"
-                style={{ flexGrow: 0 }}
+    return <div className={'dashboard'}>
+        <Tabs
+            defaultActiveKey="simsearch-projection"
+            id="uncontrolled-tab-example"
+            style={{ flexGrow: 0 }}
+        >
+            <Tab eventKey="jupyter-profiling" title="Data Profiling">
+                <ProfilingTab store={props.store} />
+            </Tab>
+            <Tab
+                eventKey="v-plots"
+                title="Descriptive Statistics (V-Plots)"
             >
-                <Tab eventKey="jupyter-profiling" title="Data Profiling">
-                    <ProfilingTab store={props.store} />
-                </Tab>
-                <Tab
-                    eventKey="v-plots"
-                    title="Descriptive Statistics (V-Plots)"
-                >
-                    <VPlotsTab store={props.store} />
-                </Tab>
-                <Tab eventKey="simsearch-projection" title="Similarity Search">
-                    <SimSearchProjectionTab />
-                </Tab>
-                <Tab eventKey="hierarchical-graph" title="Entity Resolution">
-                    <HierarchicalGraphTab store={props.store} />
-                </Tab>
-                <Tab eventKey="time-series" title="Time Series">
-                    <TimeSeriesTab store={props.store} />
-                </Tab>
-            </Tabs>
-        </div>
-    );
+                <VPlotsTab store={props.store} />
+            </Tab>
+            <Tab eventKey="simsearch-projection" title="Similarity Search">
+                <SimSearchProjectionTab />
+            </Tab>
+            <Tab eventKey="hierarchical-graph" title="Graph">
+                <HierarchicalGraphTab store={props.store} />
+            </Tab>
+            <Tab eventKey="er-graph" title="sHINER">
+                <ShinerTab store={props.store} />
+            </Tab>
+            <Tab eventKey="time-series" title="Time Series">
+                <TimeSeriesTab store={props.store} />
+            </Tab>
+        </Tabs>
+    </div>;
 };
 
 export default Dashboard;

--- a/visual-explorer/app/src/components/Dashboard/Dashboard.tsx
+++ b/visual-explorer/app/src/components/Dashboard/Dashboard.tsx
@@ -9,6 +9,7 @@ import ProfilingTab from 'components/Dashboard/ProfilingTab';
 import VPlotsTab from 'components/Dashboard/vPlotsTab';
 import TimeSeriesTab from 'components/Dashboard/TimeSeriesTab';
 import ShinerTab from "components/Dashboard/ShinerTab";
+import HierarchicalGraphTestTab from "components/Dashboard/HierarchicalGraphTestTab";
 import 'bootstrap/dist/css/bootstrap.min.css';
 
 interface IDashboardProps {
@@ -39,6 +40,9 @@ const Dashboard = (props: IDashboardProps) => {
             </Tab>
             <Tab eventKey="er-graph" title="sHINER">
                 <ShinerTab store={props.store} />
+            </Tab>
+            <Tab eventKey="htest-graph" title="H-Test">
+                <HierarchicalGraphTestTab store={props.store} />
             </Tab>
             <Tab eventKey="time-series" title="Time Series">
                 <TimeSeriesTab store={props.store} />

--- a/visual-explorer/app/src/components/Dashboard/HierarchicalGraphTestTab/HierarchicalGraphTestTab.scss
+++ b/visual-explorer/app/src/components/Dashboard/HierarchicalGraphTestTab/HierarchicalGraphTestTab.scss
@@ -1,0 +1,8 @@
+.er-graph-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  align-content: stretch;
+  flex-grow: 1;
+  height: inherit;
+}

--- a/visual-explorer/app/src/components/Dashboard/HierarchicalGraphTestTab/HierarchicalGraphTestTab.tsx
+++ b/visual-explorer/app/src/components/Dashboard/HierarchicalGraphTestTab/HierarchicalGraphTestTab.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Store } from 'redux';
+import { IApplicationState } from 'redux-types';
+import './HierarchicalGraphTestTab.scss';
+import SetParamsPanel from "./panels/setparams-panel";
+import {Card, Col, Container, Row} from "react-bootstrap";
+import {Network} from "vis-network";
+
+interface Props {
+    store: Store<IApplicationState>;
+}
+
+const HierarchicalGraphTestTab = (props: Props) => {
+    console.log('Hierarchical Graph Tab Test Param');
+
+    return (
+        <div className={'htest-graph'}>
+            <div  style={{ position: 'relative' }}>
+                <Container >
+                    <Row>
+    <Col md={10}>
+                            <Card className={'panel-card'}>
+                    <Card.Body>
+                        <Card.Title>Set Initial Params</Card.Title>
+                        <SetParamsPanel store={props.store}/>
+                    </Card.Body>
+                </Card>
+    </Col>
+  </Row>
+</Container>
+            </div>
+        </div>
+    );
+};
+
+export default HierarchicalGraphTestTab;

--- a/visual-explorer/app/src/components/Dashboard/HierarchicalGraphTestTab/index.tsx
+++ b/visual-explorer/app/src/components/Dashboard/HierarchicalGraphTestTab/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './HierarchicalGraphTestTab';

--- a/visual-explorer/app/src/components/Dashboard/HierarchicalGraphTestTab/panels/panels.scss
+++ b/visual-explorer/app/src/components/Dashboard/HierarchicalGraphTestTab/panels/panels.scss
@@ -1,0 +1,24 @@
+.panel-card {
+  width: 100%;
+  background-color: rgba(255, 255, 255, 0.95);
+  position: relative;
+  z-index: 2;
+}
+
+.panel {
+  display: block;
+  position: absolute;
+  min-width: 300px;
+  width: 30%;
+  max-width: 400px;
+
+  &.left {
+    top: 20px;
+    left: 20px;
+  }
+
+  &.right {
+    top: 20px;
+    right: 20px;
+  }
+}

--- a/visual-explorer/app/src/components/Dashboard/HierarchicalGraphTestTab/panels/setparams-panel.tsx
+++ b/visual-explorer/app/src/components/Dashboard/HierarchicalGraphTestTab/panels/setparams-panel.tsx
@@ -1,0 +1,144 @@
+import 'bootstrap/scss/bootstrap.scss';
+import React from 'react';
+import {Button, Card, Form, FormGroup} from 'react-bootstrap';
+import './panels.scss';
+import {Store} from "redux";
+import {IApplicationState} from "../../../../redux-types";
+import {getBindingElementVariableDeclaration} from "tslint";
+import VisNetwork from "../../ShinerTab/graph/visNetwork";
+
+interface SetParamsPanelProps {
+    store: Store<IApplicationState>;
+}
+
+interface SetParamsPanelState {
+    params: string
+    file: any
+    nodes: any
+    links: any
+    sim: any
+}
+
+class SetParamsPanel extends React.Component<SetParamsPanelProps, SetParamsPanelState> {
+
+    constructor(props: SetParamsPanelProps) {
+        super(props);
+        this.state = {
+            params: 'Please write your initial params here',
+            file: null,
+            nodes: undefined,
+            links: undefined,
+            sim: undefined
+        }
+        this.file = this.file.bind(this)
+    }
+
+    handleChange = (event: any) => {
+        const target = event.target
+        const value = target.value
+        this.setState({params: value});
+    }
+
+file = (evt: any) => {
+    // Retrieve the first (and only!) File from the FileList object
+    let f = evt.target.files[0];
+    this.setState({file:evt.target.files[0]})
+    if (f) {
+      let r = new FileReader();
+      r.onload = (e:any) =>{
+          // tslint:disable-next-line:prefer-const
+          var contents = e.target.result;
+          this.setState({ params: contents });
+          // alert(contents);
+      }
+      r.readAsText(f);
+      } else{
+      alert("Failed to load file");
+    }
+  }
+
+    handleSubmit = (event: any) => {
+        alert("Params submitted!");
+        event.preventDefault();
+        fetch('http://127.0.0.1:3001/graphvis/initialvis', {
+            method: 'POST',
+            // We convert the React state to JSON and send it as the POST body
+            // body: JSON.stringify(this.state)
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: this.state.params// JSON.stringify(this.state.ggds)
+        }).then(res => res.text())
+            .then(json => {
+                console.log(JSON.parse(json))
+                console.log(this.state.nodes)
+                console.log(this.state.links)
+                this.setState({
+                    nodes: JSON.parse(json)['graph']['nodes'],
+                    links: JSON.parse(json)['graph']['links'],
+                    sim: JSON.parse(json)['similarity']
+                })
+                console.log(this.state.sim)
+                //alert(JSON.parse(json))
+            }).catch((err) => {
+            console.log(err);
+        });
+    }
+
+    handleSubmitNextLevel = (event: any) => {
+                alert("Next level params submitted!");
+        event.preventDefault();
+        fetch('http://127.0.0.1:3001/graphvis/nextlevel', {
+            method: 'POST',
+            // We convert the React state to JSON and send it as the POST body
+            // body: JSON.stringify(this.state)
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: this.state.params// JSON.stringify(this.state.ggds)
+        }).then(res => res.text())
+            .then(json => {
+                console.log(JSON.parse(json))
+                console.log(this.state.nodes)
+                console.log(this.state.links)
+                this.setState({
+                    nodes: JSON.parse(json)['graph']['nodes'],
+                    links: JSON.parse(json)['graph']['links'],
+                    sim: JSON.parse(json)['similarity']
+                })
+                console.log(this.state.sim)
+                //alert(JSON.parse(json))
+            }).catch((err) => {
+            console.log(err);
+        });
+    }
+
+    render() {
+        return (
+            <div>
+            <Form onSubmit={this.handleSubmit}>
+                  <FormGroup role="form">
+                      <Form.Label>Upload your params JSON file here:</Form.Label>
+                       <input type="file" onChange={this.file} />
+                      {/*<Form.Control as="textarea" rows="6" value={this.state.ggds} onChange={this.handleChange}/>*/}
+                    <Button className="btn btn-primary btn-large centerButton" type="submit" value="Submit" >Submit</Button>
+                    </FormGroup>
+            </Form>
+            <Form onSubmit={this.handleSubmitNextLevel}>
+                  <FormGroup role="form">
+                      <Form.Label>Upload your next level params JSON file here:</Form.Label>
+                       <input type="file" onChange={this.file} />
+                      {/*<Form.Control as="textarea" rows="6" value={this.state.ggds} onChange={this.handleChange}/>*/}
+                    <Button className="btn btn-primary btn-large centerButton" type="submit" value="Submit" >Submit</Button>
+                    </FormGroup>
+            </Form>
+            Answer:
+        {this.state.nodes &&
+                    this.state.links &&
+                    <VisNetwork nodes={this.state.nodes} edges={this.state.links} />}
+            </div>
+        );
+    }
+}
+
+export default SetParamsPanel;

--- a/visual-explorer/app/src/components/Dashboard/ShinerTab/ShinerTab.scss
+++ b/visual-explorer/app/src/components/Dashboard/ShinerTab/ShinerTab.scss
@@ -1,0 +1,8 @@
+.er-graph-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  align-content: stretch;
+  flex-grow: 1;
+  height: inherit;
+}

--- a/visual-explorer/app/src/components/Dashboard/ShinerTab/ShinerTab.tsx
+++ b/visual-explorer/app/src/components/Dashboard/ShinerTab/ShinerTab.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Store } from 'redux';
+import { IApplicationState } from 'redux-types';
+import './ShinerTab.scss';
+import GraphdbPanelWrapper from "./panels/graphdb-panel-wrapper";
+import SetGGDsPanel from "./panels/setggds-panel";
+import GetGGDsPanel from "./panels/getggds-panel";
+import RunERPanel from "./panels/runer-panel";
+import SelectQueryPanelWrapper from "./gcore/select-panel";
+import ConstructQueryPanelWrapper from "./gcore/construct-panel";
+import GetNeighborPanelWrapper from "./gcore/getneighbors-panel";
+import GetNeighborGraphPanelWrapper from "./gcore/graphneighbor-panel";
+import DataPofilingPanel from "../HierarchicalGraphTab/panels/data-pofiling-panel";
+import {Card, Col, Container, Row} from "react-bootstrap";
+import VisNetwork from "./graph/visNetwork";
+import {Network} from "vis-network";
+
+interface Props {
+    store: Store<IApplicationState>;
+}
+
+const ShinerTab = (props: Props) => {
+    console.log('sHINERTab.render()');
+
+    return (
+        <div className={'er-graph-tab'}>
+            <div  style={{ position: 'relative' }}>
+                <Container fluid>
+  <Row>
+    <Col>
+        <Card className={'panel-card'}>
+                    <Card.Body>
+                        <Card.Title>Available graphs</Card.Title>
+                        <GraphdbPanelWrapper  store={props.store}/>
+                    </Card.Body>
+                </Card>
+    </Col>
+  </Row>
+                    <Row>
+    <Col md={10}>
+                            <Card className={'panel-card'}>
+                    <Card.Body>
+                        <Card.Title>GGDs: Graph Generating Dependencies</Card.Title>
+                        <SetGGDsPanel store={props.store}/>
+                         <GetGGDsPanel store={props.store}/>
+                    </Card.Body>
+                </Card>
+    </Col>
+                        <Col md={2}>
+                            <Card className={'panel-card'}>
+                    <Card.Body>
+                        <Card.Title>Entity Resolution</Card.Title>
+          <RunERPanel store={props.store}/>
+                    </Card.Body>
+                </Card>
+
+                        </Col>
+  </Row>
+                    <Row>
+                        <Col md={12}>
+                        <Card className={'panel-card'}>
+                    <Card.Body>
+                        <Card.Title>G-Core Tabular Queries</Card.Title>
+                        <SelectQueryPanelWrapper store={props.store}/>
+                    </Card.Body>
+                </Card>
+                    </Col>
+                    </Row><Row>
+                    <Col md={12}>
+                        <Card className={'panel-card'}>
+                    <Card.Body>
+                        <Card.Title>G-Core Graph Queries</Card.Title>
+                        <ConstructQueryPanelWrapper store={props.store}/>
+                    </Card.Body>
+                </Card>
+                    </Col>
+                    </Row>
+</Container>
+            </div>
+        </div>
+    );
+};
+
+export default ShinerTab;

--- a/visual-explorer/app/src/components/Dashboard/ShinerTab/gcore/ConstraintTable.jsx
+++ b/visual-explorer/app/src/components/Dashboard/ShinerTab/gcore/ConstraintTable.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import {Table} from "react-bootstrap";
+/*
+code for quick testing tables from
+https://plnkr.co/edit/ysN4Qb3lUp9mbqFhumWJ?p=preview&preview
+https://medium.com/@subalerts/create-dynamic-table-from-json-in-react-js-1a4a7b1146ef
+ */
+
+export default class ConstraintTable extends React.Component {
+
+    constructor(props) {
+        super(props);
+        /*this.state = {
+            items: this.props.data
+        }*/
+        this.constraints = this.props.data
+        this.keys = ["distance", "var1", "var2", "operator", "threshold"]
+    }
+
+          componentDidUpdate(prevProps, prevState, snapshot) {
+      if(this.props.data !== prevProps.data ) // Check if it's a new user, you can also use some unique property, like the ID  (this.props.user.id !== prevProps.user.id)
+  {
+      //alert("Change component!!!" + this.props.data)
+      this.render();
+  }
+  }
+
+
+    render() {
+        return (
+            <div>
+                <Table responsive>
+                    <thead>
+                    <tr>
+                        <th>Constraints</th>
+                        {this.keys.map((_, index) => (
+                            <th key={index}>{_}</th>
+                        ))}
+                    </tr>
+                    </thead>
+                    <tbody>
+                        {this.constraints.map((_, index) => (
+                            <tr>
+                                <td>{index}</td>
+                            <td>{_['distance']}</td>
+                            <td>{_['var1'].toString()+ "." + _['attr1'].toString()}</td>
+                            <td>{_['var2'].toString() + "." + _['attr2'].toString()}</td>
+                            <td>{_['operator']}</td>
+                            <td>{_['threshold']}</td>
+                                </tr>
+                        ))}
+                    </tbody>
+                </Table>
+            </div>
+        );
+    }
+
+
+}

--- a/visual-explorer/app/src/components/Dashboard/ShinerTab/gcore/Table.jsx
+++ b/visual-explorer/app/src/components/Dashboard/ShinerTab/gcore/Table.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import {Table} from "react-bootstrap";
+/*
+code for quick testing tables from
+https://plnkr.co/edit/ysN4Qb3lUp9mbqFhumWJ?p=preview&preview
+https://medium.com/@subalerts/create-dynamic-table-from-json-in-react-js-1a4a7b1146ef
+ */
+
+export default class TableDyn extends React.Component {
+
+    constructor(props){
+      super(props);
+      /*this.state = {
+          items: this.props.data
+      }*/
+      this.getHeader = this.getHeader.bind(this);
+      this.getRowsData = this.getRowsData.bind(this);
+      this.getKeys = this.getKeys.bind(this);
+    }
+
+    getKeys = function(){
+      return Object.keys(this.props.data[0]);
+    }
+
+    getHeader = function(){
+        const keys = this.getKeys();
+        return keys.map((key, index)=>{
+        return <th key={key}>{key.toUpperCase()}</th>
+      })
+    }
+
+    getRowsData = function(){
+        //this.items = this.props.data;
+        const items = Array.from(this.props.data)//JSON.parse(this.props.data);//Array.from(this.props.data);
+        const keys = this.getKeys();
+        return items.map((row, index)=>{
+        return <tr key={index}><RenderRow key={index} data={row} keys={keys}/></tr>
+      })
+    }
+
+    render() {
+        return (
+          <div>
+            <Table>
+            <thead>
+              <tr>{this.getHeader()}</tr>
+            </thead>
+            <tbody>
+              {this.getRowsData()}
+            </tbody>
+            </Table>
+          </div>
+        );
+    }
+}
+
+const RenderRow = (props) =>{
+  return props.keys.map((key, index)=>{
+    return <td key={props.data[key]}>{props.data[key]}</td>
+  })
+}

--- a/visual-explorer/app/src/components/Dashboard/ShinerTab/gcore/construct-panel.tsx
+++ b/visual-explorer/app/src/components/Dashboard/ShinerTab/gcore/construct-panel.tsx
@@ -1,0 +1,136 @@
+import React, {Component} from 'react';
+import {Store} from "redux";
+import * as d3 from 'd3';
+import {IApplicationState} from "../../../../redux-types";
+import {Button, Form, FormGroup, Row, ToggleButton, ToggleButtonGroup} from "react-bootstrap";
+import VisNetwork from "../graph/visNetwork";
+
+interface ConstructQueryPanelWrapperProps {
+    store: Store<IApplicationState>;
+}
+
+interface ConstructQueryPanelWrapperState {
+    //graph: string,
+    //match: string
+    //construct: string
+    query: string,
+    //answer: any
+    nodes: any,
+    links: any
+}
+
+
+/**
+ * App
+ *
+ * Simple react js fetch example
+ */
+class ConstructQueryPanelWrapper extends React.Component<ConstructQueryPanelWrapperProps, ConstructQueryPanelWrapperState> {
+
+    /**
+     * constructor
+     *
+     * @object  @props  parent props
+     * @object  @state  component state
+     */
+    constructor(props: ConstructQueryPanelWrapperProps) {
+
+        super(props);
+
+        this.state = {
+            //graph : "Graph name, AmazonGoogle",
+            //match: "Match clause, (p:ProductGoogle)",
+            //construct: "Construct clause, (p)",
+            query: "CONSTRUCT (p) MATCH (p:Person) ON people_graph",
+            //answer:  undefined
+            nodes: undefined,
+            links: undefined
+        }
+
+    }
+
+   /* handleChangeGraph = (event: any) => {
+        const target = event.target
+        const value = target.value
+        this.setState({graph: value});
+    }
+
+    handleChangeMatch = (event: any) => {
+        const target = event.target
+        const value = target.value
+        this.setState({match: value});
+    }
+
+    handleChangeConstruct = (event: any) => {
+        const target = event.target
+        const value = target.value
+        this.setState({construct: value});
+    }*/
+
+    handleChangeQuery = (event: any) => {
+        const target = event.target
+        const value = target.value
+        this.setState({query: value});
+    }
+
+    handleSubmit = (event: any) => {
+        event.preventDefault();
+        fetch('http://127.0.0.1:3001/gcore/query/construct', {
+            method: 'POST',
+            // We convert the React state to JSON and send it as the POST body
+            //body: JSON.stringify(this.state)
+            headers: {
+                 'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+                "Content-Type": "application/json"
+            },
+            //body: JSON.stringify({graph: this.state.graph, match: this.state.match, construct: this.state.construct})
+            //body: JSON.stringify({query: this.state.query})
+            body: JSON.stringify({query: this.state.query, limit:50})
+            //JSON.stringify(this.state)
+        }).then(res => res.text())
+            .then(json => {
+                this.setState({
+                    //answer: JSON.parse(json)
+                    nodes: JSON.parse(json)['nodes'],
+                    links: JSON.parse(json)['links']
+                })
+                console.log(JSON.parse(json))
+            }).catch((err) => {
+            console.log(err);
+        });
+    }
+
+    render() {
+        return (
+            <div>
+                {/*<form onSubmit={this.handleSubmit}>
+                <label>
+                    Select Query:
+                    <input value={this.state.graph} onChange={this.handleChangeGraph}/>
+                    <input value={this.state.match} onChange={this.handleChangeMatch}/>
+                    <input value={this.state.construct} onChange={this.handleChangeConstruct}/>
+                </label>
+                <input type="submit" value="Submit"/>
+            </form>*/}
+                        <Form  onSubmit={this.handleSubmit}>
+                <FormGroup role="form">
+                      <Form.Label>Construct Query</Form.Label>
+                    {/*<Form.Control type="text" value={this.state.construct} onChange={this.handleChangeConstruct}/>
+                       <Form.Control type="text" value={this.state.match} onChange={this.handleChangeMatch}/>
+                       <Form.Control type="text" value={this.state.graph} onChange={this.handleChangeGraph} />*/}
+                       <Form.Control type="text" value={this.state.query} onChange={this.handleChangeQuery}/>
+                    <Button className="btn btn-primary btn-large centerButton" type="submit" value="Submit">Submit</Button>
+                    </FormGroup>
+            </Form>
+        Answer:
+        {this.state.nodes &&
+                    this.state.links &&
+                    <VisNetwork nodes={this.state.nodes} edges={this.state.links} />}
+        </div>
+        );
+    }
+
+}
+
+export default ConstructQueryPanelWrapper;

--- a/visual-explorer/app/src/components/Dashboard/ShinerTab/gcore/getneighbors-panel.tsx
+++ b/visual-explorer/app/src/components/Dashboard/ShinerTab/gcore/getneighbors-panel.tsx
@@ -1,0 +1,112 @@
+import React, {Component} from 'react';
+import {Store} from "redux";
+import * as d3 from 'd3';
+import {IApplicationState} from "../../../../redux-types";
+import {Row, ToggleButton, ToggleButtonGroup} from "react-bootstrap";
+
+ /*   # json format for "passing node information"
+    # {
+    #        "nodeLabel": "ProductAmazon",
+    #        "id": "1",
+    #        "edgeLabel": "",
+    #        "graphName": "Amazon",
+    #        "limit": -1
+    #    }
+    #args for both select and graph neighbor*/
+
+
+interface GetNeighborPanelWrapperProps {
+    store: Store<IApplicationState>;
+}
+
+interface GetNeighborPanelWrapperState {
+    graphName: string,
+    nodeLabel: string,
+    id: string,
+    edgeLabel: string,
+    limit: number
+    answer: string
+}
+
+
+/**
+ * App
+ *
+ * Simple react js fetch example
+ */
+class GetNeighborPanelWrapper extends React.Component<GetNeighborPanelWrapperProps, GetNeighborPanelWrapperState> {
+
+    /**
+     * constructor
+     *
+     * @object  @props  parent props
+     * @object  @state  component state
+     */
+    constructor(props: GetNeighborPanelWrapperProps) {
+
+        super(props);
+
+        this.state = {
+    graphName: "AmazonGoogle",
+    nodeLabel: "ProductGoogle",
+    id: "1",
+    edgeLabel: "",
+    limit: -1,
+            answer: "query answer"
+        }
+    }
+
+    handleChangeGraph = (event: any) => {
+        const target = event.target
+        const value = target.value
+        this.setState({graphName: value});
+    }
+
+    handleChangeNode = (event: any) => {
+        const target = event.target
+        const value = target.value
+        this.setState({nodeLabel: value});
+    }
+
+    handleSubmit = (event: any) => {
+        event.preventDefault();
+        fetch('http://127.0.0.1:3001/gcore/query/select-neighbor', {
+            method: 'POST',
+            // We convert the React state to JSON and send it as the POST body
+            // body: JSON.stringify(this.state)
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify({graphName: this.state.graphName, nodeLabel: this.state.nodeLabel,
+            edgeLabel: this.state.edgeLabel, id: this.state.id, limit: this.state.limit})
+            // JSON.stringify(this.state)
+        }).then(res => res.text())
+            .then(json => {
+                this.setState({
+                    answer: JSON.stringify(json)
+                })
+                console.log(JSON.stringify(json))
+            }).catch((err) => {
+            console.log(err);
+        });
+    }
+
+    render() {
+        return (
+            <div>
+            <form onSubmit={this.handleSubmit}>
+                <label>
+                    Select Query:
+                    <input value={this.state.graphName} onChange={this.handleChangeGraph}/>
+                    <input value={this.state.nodeLabel} onChange={this.handleChangeNode}/>
+                </label>
+                <input type="submit" value="Submit"/>
+            </form>
+        Answer:{this.state.answer}
+        </div>
+        );
+    }
+
+}
+
+export default GetNeighborPanelWrapper;

--- a/visual-explorer/app/src/components/Dashboard/ShinerTab/gcore/graphneighbor-panel.tsx
+++ b/visual-explorer/app/src/components/Dashboard/ShinerTab/gcore/graphneighbor-panel.tsx
@@ -1,0 +1,112 @@
+import React, {Component} from 'react';
+import {Store} from "redux";
+import * as d3 from 'd3';
+import {IApplicationState} from "../../../../redux-types";
+import {Row, ToggleButton, ToggleButtonGroup} from "react-bootstrap";
+
+ /*   # json format for "passing node information"
+    # {
+    #        "nodeLabel": "ProductAmazon",
+    #        "id": "1",
+    #        "edgeLabel": "",
+    #        "graphName": "Amazon",
+    #        "limit": -1
+    #    }
+    #args for both select and graph neighbor*/
+
+
+interface GetNeighborGraphPanelWrapperProps {
+    store: Store<IApplicationState>;
+}
+
+interface GetNeighborGraphPanelWrapperState {
+    graphName: string,
+    nodeLabel: string,
+    id: string,
+    edgeLabel: string,
+    limit: number
+    answer: string
+}
+
+
+/**
+ * App
+ *
+ * Simple react js fetch example
+ */
+class GetNeighborGraphPanelWrapper extends React.Component<GetNeighborGraphPanelWrapperProps, GetNeighborGraphPanelWrapperState> {
+
+    /**
+     * constructor
+     *
+     * @object  @props  parent props
+     * @object  @state  component state
+     */
+    constructor(props: GetNeighborGraphPanelWrapperProps) {
+
+        super(props);
+
+        this.state = {
+    graphName: "AmazonGoogle",
+    nodeLabel: "ProductGoogle",
+    id: "1",
+    edgeLabel: "",
+    limit: -1,
+            answer: "query answer"
+        }
+    }
+
+    handleChangeGraph = (event: any) => {
+        const target = event.target
+        const value = target.value
+        this.setState({graphName: value});
+    }
+
+    handleChangeNode = (event: any) => {
+        const target = event.target
+        const value = target.value
+        this.setState({nodeLabel: value});
+    }
+
+    handleSubmit = (event: any) => {
+        event.preventDefault();
+        fetch('http://127.0.0.1:3001/gcore/query/select-neighbor', {
+            method: 'POST',
+            // We convert the React state to JSON and send it as the POST body
+            // body: JSON.stringify(this.state)
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify({graphName: this.state.graphName, nodeLabel: this.state.nodeLabel,
+            edgeLabel: this.state.edgeLabel, id: this.state.id, limit: this.state.limit})
+            // JSON.stringify(this.state)
+        }).then(res => res.text())
+            .then(json => {
+                this.setState({
+                    answer: JSON.stringify(json)
+                })
+                console.log(JSON.stringify(json))
+            }).catch((err) => {
+            console.log(err);
+        });
+    }
+
+    render() {
+        return (
+            <div>
+            <form onSubmit={this.handleSubmit}>
+                <label>
+                    Select Query:
+                    <input value={this.state.graphName} onChange={this.handleChangeGraph}/>
+                    <input value={this.state.nodeLabel} onChange={this.handleChangeNode}/>
+                </label>
+                <input type="submit" value="Submit"/>
+            </form>
+        Answer:{this.state.answer}
+        </div>
+        );
+    }
+
+}
+
+export default GetNeighborGraphPanelWrapper;

--- a/visual-explorer/app/src/components/Dashboard/ShinerTab/gcore/select-panel.tsx
+++ b/visual-explorer/app/src/components/Dashboard/ShinerTab/gcore/select-panel.tsx
@@ -1,0 +1,121 @@
+import React, {Component} from 'react';
+import {Store} from "redux";
+import * as d3 from 'd3';
+import {IApplicationState} from "../../../../redux-types";
+import {Alert, Button, Form, FormGroup, Row, ToggleButton, ToggleButtonGroup} from "react-bootstrap";
+import TableDyn from "./Table";
+import {JsonFormatter} from "tslint/lib/formatters";
+// import JsonTable from 'react-json-table'
+
+interface SelectQueryPanelWrapperProps {
+    store: Store<IApplicationState>;
+}
+
+interface SelectQueryPanelWrapperState {
+    // graph: string,
+    // table: string
+    query: string,
+    answer: any// string
+}
+
+
+/**
+ * App
+ *
+ * Simple react js fetch example
+ */
+class SelectQueryPanelWrapper extends React.Component<SelectQueryPanelWrapperProps, SelectQueryPanelWrapperState> {
+
+    /**
+     * constructor
+     *
+     * @object  @props  parent props
+     * @object  @state  component state
+     */
+    constructor(props: SelectQueryPanelWrapperProps) {
+
+        super(props);
+
+        this.state = {
+            // graph : "Graph name",
+            // table: "Label",
+            query: "SELECT * MATCH (p:Person) ON people_graph",
+            answer: [{'label': 'Label', 'id': 0}]
+        }
+
+    }
+
+    /*handleChangeGraph = (event: any) => {
+        const target = event.target
+        const value = target.value
+        this.setState({graph: value});
+    }
+
+    handleChangeTable = (event: any) => {
+        const target = event.target
+        const value = target.value
+        this.setState({table: value});
+    }*/
+
+    handleChangeQuery = (event: any) => {
+        const target = event.target
+        const value = target.value
+        this.setState({query: value});
+    }
+
+    handleSubmit = (event: any) => {
+        event.preventDefault();
+        fetch('http://127.0.0.1:3001/gcore/query/select', {
+            // mode: 'no-cors',
+            method: 'POST',
+            // We convert the React state to JSON and send it as the POST body
+            // body: JSON.stringify(this.state)
+            headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+                "Content-Type": "application/json"
+            },
+            // body: JSON.stringify({graph: this.state.graph, table: this.state.table})
+            body: JSON.stringify({query: this.state.query, limit:50})
+            // JSON.stringify(this.state)
+        }).then(res => res.text())
+            .then(json => {
+                this.setState({
+                    answer: JSON.parse(json)
+                })
+                console.log(JSON.parse(json))
+            }).catch((err) => {
+            console.log(err);
+        });
+    }
+
+    render() {
+        return (
+            <div>
+                {/*<form onSubmit={this.handleSubmit}>
+                <label>
+                    Select Query:
+                    <input value={this.state.graph} onChange={this.handleChangeGraph}/>
+                    <input value={this.state.table} onChange={this.handleChangeTable}/>
+                </label>
+                <input type="submit" value="Submit"/>
+            </form>*/}
+            <Form  onSubmit={this.handleSubmit}>
+                <FormGroup role="form">
+                      <Form.Label>Select Query</Form.Label>
+                    {/*<Form.Control type="text" value={this.state.graph} onChange={this.handleChangeGraph} placeholder="Graph Name" />
+                       <Form.Control type="text" value={this.state.table} onChange={this.handleChangeTable} placeholder="Label"/>*/}
+                       <Form.Control type="text" value={this.state.query} onChange={this.handleChangeQuery} placeholder="construct query" />
+                    <Button className="btn btn-primary btn-large centerButton" type="submit" value="Submit">Submit</Button>
+                    </FormGroup>
+            </Form>
+                {/*Answer:{this.state.answer}*/}
+         <Alert variant="info">ANSWER (Limit 50)</Alert>
+         <TableDyn data={this.state.answer}/>
+        </div>
+        );
+    }
+
+}
+
+export default SelectQueryPanelWrapper;

--- a/visual-explorer/app/src/components/Dashboard/ShinerTab/graph/visNetwork.jsx
+++ b/visual-explorer/app/src/components/Dashboard/ShinerTab/graph/visNetwork.jsx
@@ -1,0 +1,119 @@
+import React, { Component, createRef } from "react";
+import { DataSet, Network } from 'vis-network/standalone/umd/vis-network.min';
+import {Alert} from "react-bootstrap";
+import TableDyn from "../gcore/Table";
+
+// Create an array with nodes
+const nodes = new DataSet([
+    {id: 1, label: 'Node 1'},
+    {id: 2, label: 'Node 2'},
+    {id: 3, label: 'Node 3'},
+    {id: 4, label: 'Node 4'},
+    {id: 5, label: 'Node 5'}
+]);
+
+// Create an array with edges
+const edges = new DataSet([
+    {from: 1, to: 3},
+    {from: 1, to: 2},
+    {from: 2, to: 4},
+    {from: 2, to: 5}
+]);
+
+// Provide the data in the vis format
+const data = {
+  nodes: nodes,
+  edges: edges
+};
+
+const myHeight = Math.round(parseInt(window.innerHeight)*0.5) + 'px';
+
+const options = {
+    autoResize: true,
+    height: myHeight,
+     edges: {
+         arrows: {
+             to: {
+                 enabled: true
+             }
+         }
+     }
+};
+
+// Initialize your network!
+export default class VisNetwork extends React.Component {
+
+  constructor(props) {
+    super(props);
+    console.log("vis network component!!!" + this.props.name)
+    //this.nodes = this.props.nodes;
+    //console.log("props::" + this.props.nodes)
+    //this.edges = this.props.edges;
+    this.name = this.props.name;
+    this.network = {};
+    this.appRef = createRef();
+    this.state = { info: [{'label': 'Label', 'id': 0}]}
+    this.data = {
+        nodes: JSON.parse(this.props.nodes),
+        edges: JSON.parse(this.props.edges)
+    }
+  }
+
+  componentDidMount() {
+      this.name = this.props.name
+      this.data.nodes = JSON.parse(this.props.nodes);
+      this.data.edges = JSON.parse(this.props.edges);
+    //console.log("data here network!!"+ this.data.nodes)
+     if (this.data.nodes.length > 0) {
+      // console.log("data here network dentro!!"+ this.data.nodes.length)
+       this.network = new Network(this.appRef.current, this.data, options);
+       this.network.on("click",this.handleChange)
+      //   console.log(this.network)
+     }
+  }
+
+  handleChange = (networkEvents) => {
+      console.log(networkEvents)
+      //var nodesEvent = networkEvents.nodes
+      //var edgesEvent = networkEvents.edges
+      if(networkEvents.nodes.length > 0){
+          let id = networkEvents.nodes[0]
+          let nodeInformation = JSON.parse(this.props.nodes).find(element => element['id'] === id)
+          console.log(JSON.parse(this.props.nodes).find(element => element['id'] === id))
+          this.setState({
+              info: Array.of(JSON.parse(this.props.nodes).find(element => element['id'] === id))
+              //info: JSON.parse(this.props.nodes).find(element => element['id'] === id)
+          })
+      }else if(networkEvents.edges.length > 0){
+          let id = networkEvents.edges[0]
+          let edgeInformation = JSON.parse(this.props.edges).find(element => element['id'] === id)
+          let array = []
+          this.setState({
+              info:  Array.of(JSON.parse(this.props.edges).find(element => element['id'] === id))
+              //info: JSON.parse(this.props.edges).find(element => element['id'] === id)
+          })
+      }
+  }
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+      if(this.props.nodes !== prevProps.nodes && this.props.nodes.length > 0) // Check if it's a new user, you can also use some unique property, like the ID  (this.props.user.id !== prevProps.user.id)
+  {
+    //  alert("Change component!!!" + this.props.nodes)
+    this.componentDidMount();
+  }
+  }
+
+    render(){
+    return (
+        <div className={'info-network'}>
+          <Alert variant="info">
+            {console.log("This is information data" + this.state.info)}
+           <TableDyn data={this.state.info}/>
+        </Alert>
+        <div className={'vis-network'}>
+      <div ref={this.appRef}/>
+      </div>
+                    </div>
+    );
+  }
+}

--- a/visual-explorer/app/src/components/Dashboard/ShinerTab/index.tsx
+++ b/visual-explorer/app/src/components/Dashboard/ShinerTab/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ShinerTab';

--- a/visual-explorer/app/src/components/Dashboard/ShinerTab/panels/getggds-panel.tsx
+++ b/visual-explorer/app/src/components/Dashboard/ShinerTab/panels/getggds-panel.tsx
@@ -1,0 +1,130 @@
+import 'bootstrap/scss/bootstrap.scss';
+import React from 'react';
+import {Alert, Button, Card, Col, Container, ListGroup, Row, ToggleButton, ToggleButtonGroup} from 'react-bootstrap';
+import './panels.scss';
+import {Store} from "redux";
+import {IApplicationState} from "../../../../redux-types";
+import VisNetwork from "../graph/visNetwork";
+import TableDyn from "../gcore/Table";
+import ConstraintTable from "../gcore/ConstraintTable";
+
+interface GetGGDsPanelProps {
+    store: Store<IApplicationState>;
+}
+
+interface GetGGDsPanelState {
+    ggds: string
+    json: any
+}
+
+function getNodes(gp: any) {
+    const allVertices = gp.flatMap(function (gp: any) {
+        return gp.vertices
+    })
+    const verticesString = JSON.stringify(allVertices).replace(/variable/g, "id")
+    console.log(verticesString)
+    return verticesString
+    return JSON.parse(verticesString)
+}
+
+function getEdges(gp: any) {
+    const allEdges = gp.flatMap(function (gp: any) {
+        return gp.edges
+    })
+    const edgesString = JSON.stringify(allEdges).replace(/variable/g, "id")
+        .replace(/fromVariable/g, "from")
+        .replace(/toVariable/g, "to")
+    console.log(edgesString)
+    return edgesString
+    return JSON.parse(edgesString)
+}
+
+class GetGGDsPanel extends React.Component<GetGGDsPanelProps, GetGGDsPanelState> {
+
+    constructor(props: GetGGDsPanelProps) {
+        super(props);
+        this.state = {
+            ggds: "",
+            json: []
+        }
+    }
+
+    render() {
+
+        const onClickGGDs = (e: any) => {
+            console.log(e.target.value); // graph name
+            // if (e.target.value) this.props.setType(e.target.value);
+            fetch('http://127.0.0.1:3001/gcore/er/getggds')
+                .then(res => res.text())
+                .then(json => {
+                    if (JSON.parse(json).status === 'No ggds were uploaded in server!') {
+                        alert('No ggds were uploaded in server!');
+                    } else {
+                        this.setState({
+                            ggds: json,
+                            json: JSON.parse(json)
+                        })
+                    }
+                    console.log(json)
+                    // console.log(json)
+                }).catch((err) => {
+                console.log(err);
+            });
+        };// make component to render graph schemas
+
+
+        return (
+            <div className="GGDs">
+                <Button
+                    aria-label="Basic example"
+                    block={true}
+                    // type="radio"
+                    // name="schemaToggleButton"
+                    onClick={onClickGGDs}
+                >
+                    Get GGDs!
+                </Button>
+                {this.state.json.map(function (ggd: any) {
+                    return (
+                        <div className='get-ggds'>
+                            <h5>{"GGD"}</h5>
+                            <Container fluid={true}>
+                                <Row>
+                                    <Col><VisNetwork nodes={getNodes(ggd.sourceGP)}
+                                                     edges={getEdges(ggd.sourceGP)}/>
+                                    <ConstraintTable data={ggd.sourceCons} />
+                                    </Col>
+                                    <Col><VisNetwork nodes={getNodes(ggd.targetGP)}
+                                                     edges={getEdges(ggd.targetGP)}/>
+                                    <ConstraintTable data={ggd.targetCons} />
+                                    </Col>
+                                </Row>
+                            </Container>
+
+
+                            {/*<VisNetwork nodes={getNodes(ggd.sourceGP)} edges={getEdges(ggd.sourceGP)}/>
+                        <VisNetwork nodes={getNodes(ggd.targetGP)} edges={getEdges(ggd.targetGP)}/>*/}
+                        </div>
+                    )
+                    // let visNetwork = <><VisNetwork nodes={getNodes(ggd.sourceGP)} edges={getEdges(ggd.sourceGP)}/></>;
+                    // return visNetwork
+                    //    <VisNetwork nodes={getNodes(ggd.targetGP)} edges={getEdges(ggd.targetGP)} />
+                    // )
+                })}
+            </div>
+        );
+    }
+}
+
+export default GetGGDsPanel;
+
+{/*<ListGroup>
+                    {this.state.json.map(function(ggd: any){
+                        return (
+                            <ListGroup.Item>{ggd.sourceGP[0].vertices[0].label}</ListGroup.Item>
+                        )
+                        }
+
+                    )}
+                </ListGroup>*/
+}

--- a/visual-explorer/app/src/components/Dashboard/ShinerTab/panels/graphdb-panel-wrapper.tsx
+++ b/visual-explorer/app/src/components/Dashboard/ShinerTab/panels/graphdb-panel-wrapper.tsx
@@ -1,0 +1,134 @@
+import React, {Component} from 'react';
+import {Store} from "redux";
+import * as d3 from 'd3';
+import {IApplicationState} from "../../../../redux-types";
+import {Alert, Row, ToggleButton, ToggleButtonGroup} from "react-bootstrap";
+import VisNetwork from "../graph/visNetwork";
+
+interface GraphdbPanelWrapperProps {
+    store: Store<IApplicationState>;
+}
+
+interface GraphdbPanelWrapperState {
+    graphs: [],
+    graph: string,
+    isLoaded: boolean,
+    nodes?: {
+            label: string
+            property: []
+        }[]
+    links?: {
+            label: string
+            property: []
+            source: string
+            target: string
+        }[]
+}
+
+
+/**
+ * App
+ *
+ * Simple react js fetch example
+ */
+class GraphdbPanelWrapper extends React.Component<GraphdbPanelWrapperProps, GraphdbPanelWrapperState> {
+
+    /**
+     * constructor
+     *
+     * @object  @props  parent props
+     * @object  @state  component state
+     */
+    constructor(props: GraphdbPanelWrapperProps) {
+
+        super(props);
+
+        this.state = {
+            graphs: [],
+            isLoaded: false,
+            graph: "schema-graph",
+            // schema : undefined
+            nodes: undefined,
+            links: undefined
+        }
+
+    }
+
+    /**
+     * componentDidMount
+     *
+     * Fetch json array of objects from given url and update state.
+     */
+    componentDidMount() {
+
+        fetch('http://127.0.0.1:3001/gcore/availableGraphs')
+            .then(res => res.json())
+            .then(json => {
+                this.setState({
+                    graphs: json,
+                    isLoaded: true,
+                })
+            }).catch((err) => {
+            console.log(err);
+        });
+
+    }
+
+    /**
+     * render
+     *
+     * Render UI
+     */
+    render() {
+
+        const onGraphChangeFn = (e: any) => {
+            console.log(e.target.value); // graph name
+           // if (e.target.value) this.props.setType(e.target.value);
+            const graphValue = e.target.value;
+            fetch('http://127.0.0.1:3001/gcore/schema/' + e.target.value)
+            .then(res => res.json())
+            .then(json => {
+                this.setState({
+                    nodes: json.nodes,
+                    links: json.links
+                })
+                console.log(json)
+            }).catch((err) => {
+            console.log(err);
+        });
+            this.setState({
+                graph: graphValue
+            })
+        };// make component to render graph schemas
+
+        const {isLoaded, graphs} = this.state;
+
+        if (!isLoaded)
+            return <div>  <Alert variant="warning"> Loading...(check for connection or load database error)
+  </Alert></div>;
+
+        return (
+            <div className="GraphDB" >
+                <ToggleButtonGroup
+                    type="radio"
+                    name="schemaToggleButton"
+                    onClick={onGraphChangeFn}
+                    defaultValue={graphs.entries().next()}
+                >
+                    {graphs.map(graph => (
+                        <ToggleButton value={graph} variant="primary">
+                            {graph}
+                        </ToggleButton>
+                    ))}
+                </ToggleButtonGroup>
+                    {this.state.nodes &&
+                    this.state.links &&
+                    <VisNetwork nodes={this.state.nodes} edges={this.state.links} name={this.state.graph}/>}
+            </div>
+        );
+
+    }
+
+}
+
+export default GraphdbPanelWrapper;

--- a/visual-explorer/app/src/components/Dashboard/ShinerTab/panels/panels.scss
+++ b/visual-explorer/app/src/components/Dashboard/ShinerTab/panels/panels.scss
@@ -1,0 +1,24 @@
+.panel-card {
+  width: 100%;
+  background-color: rgba(255, 255, 255, 0.95);
+  position: relative;
+  z-index: 2;
+}
+
+.panel {
+  display: block;
+  position: absolute;
+  min-width: 300px;
+  width: 30%;
+  max-width: 400px;
+
+  &.left {
+    top: 20px;
+    left: 20px;
+  }
+
+  &.right {
+    top: 20px;
+    right: 20px;
+  }
+}

--- a/visual-explorer/app/src/components/Dashboard/ShinerTab/panels/runer-panel.tsx
+++ b/visual-explorer/app/src/components/Dashboard/ShinerTab/panels/runer-panel.tsx
@@ -1,0 +1,80 @@
+import 'bootstrap/scss/bootstrap.scss';
+import React from 'react';
+import {Alert, Button, Card, ToggleButton, ToggleButtonGroup} from 'react-bootstrap';
+import './panels.scss';
+import {Store} from "redux";
+import {IApplicationState} from "../../../../redux-types";
+import TableDyn from "../gcore/Table";
+
+interface RunerPanelProps {
+    store: Store<IApplicationState>;
+}
+
+interface RunerPanelState {
+    status: string
+    info: any
+}
+
+class RunERPanel extends React.Component<RunerPanelProps, RunerPanelState> {
+
+    constructor(props: RunerPanelProps) {
+        super(props);
+        this.state = {
+            status: 'Click to run',
+            info: [{'name': 'Label', 'number': 0}]
+        }
+    }
+
+    render() {
+
+        const onClickRun = (e: any) => {
+            this.setState({
+                status: 'Running....'
+            })
+            // if (e.target.value) this.props.setType(e.target.value);
+            fetch('http://127.0.0.1:3001/gcore/er/run',{
+             //   mode: 'cors'
+             /*   method: 'POST',
+            // We convert the React state to JSON and send it as the POST body
+            //body: JSON.stringify(this.state)*/
+            headers: {
+                 'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+                "Content-Type": "application/json"
+            }
+            })
+                .then(res => res.text())
+                .then(json => {
+                    this.setState({
+                        status: "Resulting graph name:" + JSON.parse(json)['graphName'],
+                        info: JSON.parse(json)['resultInfo']
+                    })
+                    console.log(json)
+                }).catch((err) => {
+                console.log(err);
+            });
+        };//make component to render graph schemas
+
+
+        return (
+            <div className="RunER">
+                <Button
+                    aria-label="Basic example"
+                    size='lg'
+                    //type="radio"
+                    //name="schemaToggleButton"
+                    block
+                    onClick={onClickRun}
+                >
+                    Run ER!
+                </Button>
+                <Alert variant="info">
+                    {this.state.status}
+                </Alert>
+                <TableDyn data={this.state.info}/>
+            </div>
+        );
+    }
+}
+
+export default RunERPanel;

--- a/visual-explorer/app/src/components/Dashboard/ShinerTab/panels/setggds-panel.tsx
+++ b/visual-explorer/app/src/components/Dashboard/ShinerTab/panels/setggds-panel.tsx
@@ -1,0 +1,95 @@
+import 'bootstrap/scss/bootstrap.scss';
+import React from 'react';
+import {Button, Card, Form, FormGroup} from 'react-bootstrap';
+import './panels.scss';
+import {Store} from "redux";
+import {IApplicationState} from "../../../../redux-types";
+import {getBindingElementVariableDeclaration} from "tslint";
+
+interface SetGGDsPanelProps {
+    store: Store<IApplicationState>;
+}
+
+interface SetGGDsPanelState {
+    ggds: string
+    file: any
+}
+
+class SetGGDsPanel extends React.Component<SetGGDsPanelProps, SetGGDsPanelState> {
+
+    constructor(props: SetGGDsPanelProps) {
+        super(props);
+        this.state = {
+            ggds: 'Please write your GGDs here',
+            file: null
+        }
+        this.file = this.file.bind(this)
+    }
+
+    handleChange = (event: any) => {
+        const target = event.target
+        const value = target.value
+        this.setState({ggds: value});
+    }
+
+file = (evt: any) => {
+    // Retrieve the first (and only!) File from the FileList object
+    let f = evt.target.files[0];
+    this.setState({file:evt.target.files[0]})
+    if (f) {
+      let r = new FileReader();
+      r.onload = (e:any) =>{
+          // tslint:disable-next-line:prefer-const
+          var contents = e.target.result;
+          this.setState({ ggds: contents });
+          // alert(contents);
+      }
+      r.readAsText(f);
+      } else{
+      alert("Failed to load file");
+    }
+  }
+
+    handleSubmit = (event: any) => {
+        alert("GGDs submitted!");
+        event.preventDefault();
+        fetch('http://127.0.0.1:3001/gcore/er/setggds', {
+            method: 'POST',
+            // We convert the React state to JSON and send it as the POST body
+            // body: JSON.stringify(this.state)
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: this.state.ggds// JSON.stringify(this.state.ggds)
+        }).then(res => res.text())
+            .then(json => {
+                console.log(JSON.stringify(json))
+                alert(JSON.stringify(json))
+                // alert("Graph Generating Dependencies submitted!")
+            }).catch((err) => {
+            console.log(err);
+        });
+    }
+
+    render() {
+        return (
+            <Form onSubmit={this.handleSubmit}>
+                  <FormGroup role="form">
+                      <Form.Label>Upload you GGDs JSON file here:</Form.Label>
+                       <input type="file" onChange={this.file} />
+                      {/*<Form.Control as="textarea" rows="6" value={this.state.ggds} onChange={this.handleChange}/>*/}
+                    <Button className="btn btn-primary btn-large centerButton" type="submit" value="Submit" block>Submit</Button>
+                    </FormGroup>
+            </Form>
+                /*<form onSubmit={this.handleSubmit}>
+                    <label>
+                    GGDs:
+                    <textarea value={this.state.ggds} onChange={this.handleChange}/>
+                </label>
+                <input type="submit" value="Submit"/>
+            </form>*/
+        );
+    }
+}
+
+export default SetGGDsPanel;


### PR DESCRIPTION
This is a pull request to add the G-Core REST API to the visual analytics engine and the additional tab called ShinerTab for a simplified visualization of Entity Resolution in the visual-explorer.

The gcore.env was added to the docker-compose to set the Rest API URL.  
Also added the following dependencies in the package.json to use the vis-network library in the query results visualization :     "uuid": "^7.0.3", "vis-data": "^7.0.0", "vis-network": "^8.2.0", "vis-util": "^4.3.4